### PR TITLE
Fix error on oracle databases

### DIFF
--- a/src/Widgets/ActivityChartWidget.php
+++ b/src/Widgets/ActivityChartWidget.php
@@ -111,7 +111,7 @@ class ActivityChartWidget extends ChartWidget
             ->groupBy(DB::raw($dateExpression))
             ->orderBy(DB::raw($dateExpression))
             ->get()
-            ->pluck('count', 'actvity_date');
+            ->pluck('count', 'activity_date');
 
         return [
             'datasets' => [


### PR DESCRIPTION
Oracle does not support `DATE()` and treats `DATE` as a reserved keyword, which breaks parsing and grouping.

Make activity date aggregation database-agnostic by replacing the `DATE()` function and reserved date alias with a driver-specific `DATE` expression and a safe alias, fixing Oracle SQL errors while preserving correct grouping across all supported databases.
Also, using an alias in a `GROUP BY` statement is only supported in MySQL, as far as I know.