### PR TITLE
Respect activitylog.activity_model config in table and page queries

### DIFF
--- a/src/Pages/UserActivitiesPage.php
+++ b/src/Pages/UserActivitiesPage.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace AlizHarb\ActivityLog\Pages;
 
 use AlizHarb\ActivityLog\ActivityLogPlugin;
-use AlizHarb\ActivityLog\Models\Activity;
 use AlizHarb\ActivityLog\Resources\ActivityLogs\ActivityLogResource;
 use AlizHarb\ActivityLog\Support\ActivityLogCauser;
 use Filament\Pages\Page;
@@ -16,6 +15,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
+use Spatie\Activitylog\Models\Activity;
 use UnitEnum;
 
 /**
@@ -99,7 +99,7 @@ class UserActivitiesPage extends Page implements HasTable
     public function table(Table $table): Table
     {
         return $table
-            ->query(fn () => Activity::query()
+            ->query(fn () => (config('activitylog.activity_model') ?? Activity::class)::query()
                 ->with(['causer', 'subject'])
                 ->whereNotNull('causer_id')
                 ->latest())
@@ -177,7 +177,7 @@ class UserActivitiesPage extends Page implements HasTable
                     ->label(__('filament-activity-log::activity.filter.subject_type'))
                     ->options(function () {
                         /** @var Builder $query */
-                        $query = Activity::query();
+                        $query = (config('activitylog.activity_model') ?? Activity::class)::query();
 
                         return $query
                             ->whereNotNull('subject_type')

--- a/src/Resources/ActivityLogs/Tables/ActivityLogTable.php
+++ b/src/Resources/ActivityLogs/Tables/ActivityLogTable.php
@@ -5,7 +5,6 @@ namespace AlizHarb\ActivityLog\Resources\ActivityLogs\Tables;
 use AlizHarb\ActivityLog\Actions\ActivityLogTimelineTableAction;
 use AlizHarb\ActivityLog\Enums\ActivityLogEvent;
 use AlizHarb\ActivityLog\Exporters\ActivityLogExporter;
-use AlizHarb\ActivityLog\Models\Activity;
 use AlizHarb\ActivityLog\Support\ActivityChanges;
 use AlizHarb\ActivityLog\Support\ActivityGrouping;
 use AlizHarb\ActivityLog\Support\ActivityLogCauser;
@@ -32,6 +31,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Gate;
+use Spatie\Activitylog\Models\Activity;
 
 /**
  * Class ActivityLogTable
@@ -205,7 +205,7 @@ class ActivityLogTable
             ->filters([
                 SelectFilter::make('log_name')
                     ->label(__('filament-activity-log::activity.table.column.log_name'))
-                    ->options(fn () => Activity::query()->distinct()->whereNotNull('log_name')->pluck('log_name', 'log_name')->toArray())
+                    ->options(fn () => (config('activitylog.activity_model') ?? Activity::class)::query()->distinct()->whereNotNull('log_name')->pluck('log_name', 'log_name')->toArray())
                     ->visible(config('filament-activity-log.table.filters.log_name', true)),
 
                 SelectFilter::make('event')
@@ -221,7 +221,7 @@ class ActivityLogTable
                             return [];
                         }
 
-                        $query = $causerClass::query()->whereIn('id', Activity::query()
+                        $query = $causerClass::query()->whereIn('id', (config('activitylog.activity_model') ?? Activity::class)::query()
                             ->distinct()
                             ->whereNotNull('causer_id')
                             ->pluck('causer_id')
@@ -234,7 +234,7 @@ class ActivityLogTable
 
                 SelectFilter::make('subject_type')
                     ->label(__('filament-activity-log::activity.table.filter.subject_type'))
-                    ->options(fn () => Activity::query()
+                    ->options(fn () => (config('activitylog.activity_model') ?? Activity::class)::query()
                         ->distinct()
                         ->whereNotNull('subject_type')
                         ->pluck('subject_type', 'subject_type')
@@ -305,7 +305,7 @@ class ActivityLogTable
                     ->modalHeading(__('filament-activity-log::activity.action.prune.heading'))
                     ->modalDescription(__('filament-activity-log::activity.action.prune.confirmation'))
                     ->action(function (array $data) {
-                        $count = Activity::query()
+                        $count = (config('activitylog.activity_model') ?? Activity::class)::query()
                             ->where('created_at', '<', $data['prune_until'])
                             ->delete();
 


### PR DESCRIPTION
Fixes #36

## Summary

`ActivityLogTable` (the `log_name`/`causer_id`/`subject_type` filters and the `prune` action) and `UserActivitiesPage` (main table query + `subject_type` filter) import and use the package's own `AlizHarb\ActivityLog\Models\Activity` directly, instead of resolving the model the same way `ActivityLogResource::getModel()` and every widget already do:

```php
config('activitylog.activity_model') ?? Activity::class
```

For apps that set a custom `activity_model` (e.g. a subclass pointed at a separate database connection, per Spatie's own docs on isolating activity logs), this makes those two files query the wrong model/connection and throw a `QueryException` — see #36 for the exact reproduction and error.

## Change

- Swapped the `use AlizHarb\ActivityLog\Models\Activity;` import for `use Spatie\Activitylog\Models\Activity;` in both files (matching every other file in the package).
- Wrapped each `Activity::query()` call with `(config('activitylog.activity_model') ?? Activity::class)::query()`.

No behavior change for apps using the default Activity model — `config('activitylog.activity_model')` is `null` unless explicitly set, so it falls back to the same `Activity::class` these files used before.

## Test plan

- [x] Verified locally against an app with a custom `activity_model` pointed at a separate connection: Activity Log resource page (table + all three filters + prune action) and User Activities page both load and query correctly after this change.
- Scope kept intentionally minimal/consistent with the existing pattern; happy to follow up with a shared helper to dedupe the `config('activitylog.activity_model') ?? Activity::class` resolution if that's preferred.