### PR TITLE
Make subject title attributes configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- `subject.title_attributes` config option to define which model attributes (and in which order) are used as the subject title when a model does not implement `HasActivityLogTitle`.
+
 ## [2.0.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -256,8 +256,24 @@ public static function getRelations(): array
 
 ### 🏷️ Customizable Subject Titles
 
-The package automatically checks for `name`, `title`, or `label` attributes on your models.
-For more control, implement the `HasActivityLogTitle` interface on your model:
+By default the package checks the following attributes on your models, in order, and uses the first one that exists:
+
+```php
+// config/filament-activity-log.php
+'subject' => [
+    'title_attributes' => ['name', 'title', 'email', 'username', 'label'],
+],
+```
+
+You can change that list (and its order) globally — handy when your models share an internal attribute such as `working_title`:
+
+```php
+'subject' => [
+    'title_attributes' => ['working_title', 'name', 'title', 'email', 'username', 'label'],
+],
+```
+
+For full control on a specific model, implement the `HasActivityLogTitle` interface:
 
 ```php
 use AlizHarb\ActivityLog\Contracts\HasActivityLogTitle;

--- a/config/filament-activity-log.php
+++ b/config/filament-activity-log.php
@@ -551,4 +551,18 @@ return [
     'causer' => [
         'display_attribute' => 'name',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subject Settings
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for the subject (the record an activity was performed on).
+    | When a subject does not implement HasActivityLogTitle, the first of these
+    | attributes that exists on the model is used as its display title.
+    |
+    */
+    'subject' => [
+        'title_attributes' => ['name', 'title', 'email', 'username', 'label'],
+    ],
 ];

--- a/src/Support/ActivityLogTitle.php
+++ b/src/Support/ActivityLogTitle.php
@@ -55,7 +55,7 @@ class ActivityLogTitle
             return $model->getActivityLogTitle();
         }
 
-        foreach (['name', 'title', 'email', 'username', 'label'] as $attribute) {
+        foreach (config('filament-activity-log.subject.title_attributes', []) as $attribute) {
             if ($model->hasAttribute($attribute)) {
                 return (string) $model->getAttribute($attribute);
             }

--- a/tests/Feature/ImprovementsTest.php
+++ b/tests/Feature/ImprovementsTest.php
@@ -74,6 +74,48 @@ it('resolves subject title using helper', function () {
     expect(ActivityLogTitle::get($unknown))->toContain('#3');
 });
 
+it('resolves activity log titles from the configured subject attributes', function () {
+    config()->set('filament-activity-log.subject.title_attributes', ['working_title', 'name']);
+
+    $page = new class extends Model
+    {
+        protected $guarded = [];
+    };
+    $page->setAttribute('name', 'Public name');
+    $page->setAttribute('working_title', 'Internal working title');
+    $page->setAttribute('id', 4);
+
+    expect(ActivityLogTitle::get($page))->toBe('Internal working title');
+
+    $user = new class extends Model
+    {
+        protected $guarded = [];
+    };
+    $user->setAttribute('name', 'Test User');
+    $user->setAttribute('title', 'Ignored title');
+    $user->setAttribute('id', 5);
+
+    expect(ActivityLogTitle::get($user))->toBe('Test User');
+});
+
+it('ignores subject title attributes that are not present on the model', function () {
+    config()->set('filament-activity-log.subject.title_attributes', ['working_title']);
+
+    $post = new class extends Model
+    {
+        protected $guarded = [];
+
+        public function getTable()
+        {
+            return 'posts';
+        }
+    };
+    $post->setAttribute('title', 'Test Post');
+    $post->setAttribute('id', 6);
+
+    expect(ActivityLogTitle::get($post))->toContain('#6');
+});
+
 it('applies v4 native batch_uuid filter', function () {
     if (! TestCase::isSpatieV4()) {
         $this->markTestSkipped('Only runs on Spatie v4 (native batch_uuid).');


### PR DESCRIPTION
## Summary

Add a `subject.title_attributes` config option that defines which model attributes (and in which order) are used as the activity subject title when a model does not implement `HasActivityLogTitle`. Defaults to the previously hardcoded list, so existing installations are unaffected.

Useful when models share an internal attribute (e.g. `working_title`) that should take precedence over the public/translated `name` or `title`, without implementing the interface on every model.

## Verification

- [x] Added or updated tests
- [x] `composer test` passes
- [x] `vendor/bin/phpstan analyse --memory-limit=2G` passes
- [x] `vendor/bin/pint --test` passes
- [x] Documentation and changelog are updated when behavior changes

## Compatibility and safety

- [x] Considered Filament 4 and 5
- [x] Considered Spatie Activitylog 4 and 5
- [x] Considered tenant/query scoping
- [x] Considered authorization, redaction, exports, and destructive actions

